### PR TITLE
Update rubies travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
+  - 2.2
   - jruby
 notifications:
   recipients:


### PR DESCRIPTION
Use latest Ruby 2.1 and Ruby 2.2 in Travis.
