### PR TITLE
Add support for capybara 3

### DIFF
--- a/lib/test/unit/capybara.rb
+++ b/lib/test/unit/capybara.rb
@@ -374,10 +374,14 @@ EOT
         node = nil
         node = args.shift if args[0].is_a?(::Capybara::Node::Base)
         args = normalize_page_finder_arguments(args)
-        if node
-          element = node.first(*args[:finder_arguments])
-        else
-          element = first(*args[:finder_arguments])
+        begin
+          if node
+            element = node.first(*args[:finder_arguments])
+          else
+            element = first(*args[:finder_arguments])
+          end
+        rescue ::Capybara::ExpectationNotMet
+          element = nil
         end
         format = <<-EOT
 <?>(?) expected to not find a element but was

--- a/lib/test/unit/capybara.rb
+++ b/lib/test/unit/capybara.rb
@@ -70,7 +70,11 @@ module Test::Unit
         begin
           super
         rescue ::Capybara::ElementNotFound => error
-          query = ::Capybara::Query.new(*args)
+          if ::Capybara::VERSION >= "3.0.0.rc1"
+            query = ::Capybara::Queries::SelectorQuery.new(*args, session_options: session_options)
+          else
+            query = ::Capybara::Query.new(*args)
+          end
           new_error = ElementNotFound.new(self,
                                           query.selector.name,
                                           query.locator,

--- a/test/test-unit-capybara-test-utils.rb
+++ b/test/test-unit-capybara-test-utils.rb
@@ -25,4 +25,8 @@ require "test/unit/capybara"
 require "pp"
 
 tmp_path = File.expand_path(File.join("tmp", "capybara"), __FILE__)
-Capybara.save_and_open_page_path = tmp_path
+if Capybara::VERSION >= "3.0.0.rc1"
+  Capybara.save_path = tmp_path
+else
+  Capybara.save_and_open_page_path= tmp_path
+end


### PR DESCRIPTION
## Summary
Add support for higher than capybara 3 keeping backward compatibility.

## Other Information
This pull request run tests with Capybara 2.18, 3.0.0.rc0 and 3.2.0 at local envriroment.



