### PR TITLE
Convert to markdown

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,2 +1,3 @@
 --no-private
---markup textile
+--markup markdown
+--markup-provider redcarpet

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-h1. test-unit-capybara
+# test-unit-capybara
 
-"Web site":https://github.com/test-unit/test-unit-capybara
+[Web site](https://github.com/test-unit/test-unit-capybara)
 
-h2. Description
+## Description
 
-test-unit-capybara is a Capybara adapter for test-unit 2. You can get "Capybara":https://rubygems.org/gems/capybara integrated Test::Unit::TestCase. It also provides useful assertions for Capybara.
+test-unit-capybara is a Capybara adapter for test-unit 2. You can get [Capybara](https://rubygems.org/gems/capybara) integrated Test::Unit::TestCase. It also provides useful assertions for Capybara.
 
-h2. Install
+## Install
 
-<pre>
+```
 % sudo gem install test-unit-capybara
-</pre>
+```
 
-h2. Usage
+## Usage
 
-<pre>
+```ruby
 require 'test/unit/capybara'
 
 class MyRackApplication
@@ -74,14 +74,14 @@ class TestMyRackApplication < Test::Unit::TestCase
     end
   end
 end
-</pre>
+```
 
-h2. License
+## License
 
 LGPLv2.1 or later.
 
 (Kouhei Sutou has a right to change the license including contributed patches.)
 
-h2. Authors
+## Authors
 
 * Kouhei Sutou

--- a/doc/text/news.md
+++ b/doc/text/news.md
@@ -1,8 +1,8 @@
-h1. News
+# News
 
-h2(#1-0-6). 1.0.6 - 2018-06-06
+## 1.0.6 - 2018-06-06
 
-h3. Improvements
+### Improvements
 
 * Improved release script.
   [GitHub#5] [Patch by Hiroyuki Sato]
@@ -13,7 +13,7 @@ h3. Improvements
 * Added support for Capybara 3.
   [GitHub#7] [Patch by neko maho]
 
-h3. Thanks
+### Thanks
 
 * Hiroyuki Sato
 
@@ -21,55 +21,55 @@ h3. Thanks
 
 * neko maho
 
-h2(#1-0-5). 1.0.5 - 2016-01-18
+## 1.0.5 - 2016-01-18
 
-h3. Improvements
+### Improvements
 
 * Stopped to register auto test runner.
 
-h2(#1-0-4). 1.0.4 - 2013-05-15
+## 1.0.4 - 2013-05-15
 
 A Capybara 2.1.0 support release.
 
-h3. Improvements
+### Improvements
 
 * Supported Capybara 2.1.0.
   It requires Capybara >= 2.1.0.
   Notice: Capybara < 2.1.0 aren't supported from this release.
   [GitHub#2] [Reported by thelastinuit]
 
-h3. Thanks
+### Thanks
 
 * thelastinuit
 
-h2(#1-0-3). 1.0.3 - 2012-11-29
+## 1.0.3 - 2012-11-29
 
 A support Capybara 2.0.1 release.
 
-h3. Improvments
+### Improvments
 
 * Supported Capybara 2.0.1.
   It requires Capybara >= 2.0.1 and test-unit >= 2.5.3.
   Notice: Capybara 1.X aren't supported yet from this release.
 
-h2(#1-0-2). 1.0.2 - 2012-03-12
+## 1.0.2 - 2012-03-12
 
 A Capybara integration improvement release.
 
-h3. Improvments
+### Improvments
 
   * Supported Capybara 1.1.2 again.
 
-h2(#1-0-1). 1.0.1 - 2012-01-16
+## 1.0.1 - 2012-01-16
 
 A Capybara integration improvement release.
 
-h3. Improvments
+### Improvments
 
   * Added {Test::Unit::Capybara::Assertions#assert_all}.
   * Added {Test::Unit::Capybara::Assertions#assert_not_find}.
   * Supported Capybara::ElementNotFound as a failure.
 
-h2(#1-0-0). 1.0.0 - 2011-05-01
+## 1.0.0 - 2011-05-01
 
 The first release!!!

--- a/test-unit-capybara.gemspec
+++ b/test-unit-capybara.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("yard")
   spec.add_development_dependency("packnga")
   spec.add_development_dependency("test-unit-notify")
-  spec.add_development_dependency("RedCloth")
+  spec.add_development_dependency("redcarpet")
 end

--- a/test-unit-capybara.gemspec
+++ b/test-unit-capybara.gemspec
@@ -14,14 +14,14 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/test-unit/test-unit-capybara"
   spec.authors = ["Kouhei Sutou"]
   spec.email = ["kou@clear-code.com"]
-  entries = File.read("README.textile").split(/^h2\.\s(.*)$/)
+  entries = File.read("README.md").split(/^##\s(.*)$/)
   description = clean_white_space.call(entries[entries.index("Description") + 1])
   spec.summary, spec.description, = description.split(/\n\n+/, 3)
   spec.license = "LGPLv2 or later"
   spec.files += Dir.glob("lib/**/*.rb")
   spec.files += Dir.glob("bin/*")
   spec.files += Dir.glob("doc/text/*")
-  spec.files += ["README.textile", "COPYING", "Rakefile", "Gemfile"]
+  spec.files += ["README.md", "COPYING", "Rakefile", "Gemfile"]
   spec.test_files = Dir.glob("test/**/*.rb")
 
   spec.add_runtime_dependency("test-unit", ">=2.5.3")


### PR DESCRIPTION
Use redcarpet to process GFM style syntax highlighting.