### PR TITLE
 Apply interface change of Capybara::Node::Finders#find

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,8 @@ rvm:
 notifications:
   webhooks:
     - https://webhook.commit-email.info/
+gemfile:
+  - gemfiles/capybara2.gemfile
+  - gemfiles/capybara3.gemfile
 before_install:
   - gem update bundler

--- a/gemfiles/capybara2.gemfile
+++ b/gemfiles/capybara2.gemfile
@@ -1,0 +1,23 @@
+# -*- ruby -*-
+#
+# Copyright (C) 2016  Kouhei Sutou <kou@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+source "https://rubygems.org/"
+
+gemspec path: ".."
+
+gem "capybara", "< 3.0.0.rc1"

--- a/gemfiles/capybara3.gemfile
+++ b/gemfiles/capybara3.gemfile
@@ -1,0 +1,23 @@
+# -*- ruby -*-
+#
+# Copyright (C) 2016  Kouhei Sutou <kou@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+source "https://rubygems.org/"
+
+gemspec path: ".."
+
+gem "capybara", "< 4"

--- a/lib/test/unit/capybara.rb
+++ b/lib/test/unit/capybara.rb
@@ -68,7 +68,7 @@ module Test::Unit
     module FindErrorWrapper
       if ::Capybara::VERSION >= "3.0.0.rc1"
         def find(*args, **options, &optional_filter_block)
-          super(*args, options, &optional_filter_block)
+          super
         rescue ::Capybara::ElementNotFound => error
           options[:session_options] = session_options
           query = ::Capybara::Queries::SelectorQuery.new(*args, options, &optional_filter_block)


### PR DESCRIPTION
## Description
Capybara::Node::Finders#find change interface from 3.0.0.rc1.
This PR apply interface change of it and adding following capybara versions  gemfiles for CI test.
- under 3.0.0.rc1
  - gemfiles/capybara2.gemfile
- under 4
  - gemfiles/capybara3.gemfile

https://github.com/teamcapybara/capybara/blob/3.0.0.rc1/lib/capybara/node/finders.rb
https://github.com/teamcapybara/capybara/blob/2.18.0/lib/capybara/node/finders.rb

